### PR TITLE
Make oxmysql compatible with the version 2.0.1.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ name:: `oxmysql`
 resource:: `vrp_oxmysql`
 project:: https://github.com/overextended/oxmysql/
 
-NOTE: oxmysql resource is required.
+NOTE: oxmysql resource 2.0.1 or later is required.
 
 [WARNING]
 The vRP database configuration is not supported; oxmysql configuration must be used instead. +


### PR DESCRIPTION
Hello, I decided to use the exports to avoid the global scope at all costs now that version 2 has been officially released and the new API defined. I made sure binary data is working as expected and hopefully all the other cases. Let me know if you'd like any more changes.